### PR TITLE
Pass extra arguments onwards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ macro_rules! dep_doc {
     ( $( $tt:tt )* ) => {
         concat!(
             "```TOML\n[dependencies]\n",
-            $crate::package_import!(),
+            $crate::package_import!($($tt)*),
             "\n```",
         )
     };
@@ -132,7 +132,7 @@ macro_rules! dev_dep_doc {
     ( $( $tt:tt )* ) => {
         concat!(
             "```TOML\n[dev-dependencies]\n",
-            $crate::package_import!(),
+            $crate::package_import!($($tt)*),
             "\n```",
         )
     };


### PR DESCRIPTION
It's documented that one can pass any further options,
but these weren't passed on and thus always ignored.

---

Thank you for this crate!