### PR TITLE
Add badges in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Latest Version][version-badge]][version-url]
 [![Rust Documentation][docs-badge]][docs-url]
 
-[actions-badge]: https://github.com/yaahc/dep_doc/workflows/Continuous%20integration/badge.svg
-[actions-url]: https://github.com/scrabsha/dep_doc/actions?query=workflow%3A%22Continuous+integration%22
+[actions-badge]: https://github.com/scrabsha/dep-doc/actions/workflows/ci.yml/badge.svg
+[actions-url]: https://github.com/scrabsha/dep-doc/actions/workflows/ci.yml?query=branch%3Amain
 [version-badge]: https://img.shields.io/crates/v/dep_doc.svg
 [version-url]: https://crates.io/crates/dep_doc
 [docs-badge]: https://img.shields.io/badge/docs-latest-blue.svg

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # `dep_doc`
 
+[![Build Status][actions-badge]][actions-url]
+[![Latest Version][version-badge]][version-url]
+[![Rust Documentation][docs-badge]][docs-url]
+
+[actions-badge]: https://github.com/yaahc/dep_doc/workflows/Continuous%20integration/badge.svg
+[actions-url]: https://github.com/scrabsha/dep_doc/actions?query=workflow%3A%22Continuous+integration%22
+[version-badge]: https://img.shields.io/crates/v/dep_doc.svg
+[version-url]: https://crates.io/crates/dep_doc
+[docs-badge]: https://img.shields.io/badge/docs-latest-blue.svg
+[docs-url]: https://docs.rs/dep_doc
+
+
 Add a cute dependency declaration snippet in your crate documentation.
 
 ## Adding to `Cargo.toml`


### PR DESCRIPTION
A screenshot is worth a thousand of words:

![A screenshot of the top of the readme file. We can see the crate name and three badges, respectively the Continuous Integration Status, the link to crates.io and the link to docs.rs](https://user-images.githubusercontent.com/25402018/142852264-167982f1-bc22-44c8-9c91-b258e0eb758d.png)
